### PR TITLE
Removing shots_count so that advanced vqe example displays correct minimum cost

### DIFF
--- a/docs/sphinx/examples/python/advanced_vqe.py
+++ b/docs/sphinx/examples/python/advanced_vqe.py
@@ -51,7 +51,7 @@ def objective_function(parameter_vector: List[float],
     # function. If you were using a gradient-free optimizer,
     # you could purely define `cost = cudaq.observe().expectation()`.
     get_result = lambda parameter_vector: cudaq.observe(
-        kernel, hamiltonian, parameter_vector, shots_count=100).expectation()
+        kernel, hamiltonian, parameter_vector).expectation()
     # `cudaq.observe` returns a `cudaq.ObserveResult` that holds the
     # counts dictionary and the `expectation`.
     cost = get_result(parameter_vector)


### PR DESCRIPTION
This change will fix the output result, which shows the minimum cost after running vqe algorithm

root@5602d3afa039:/workspaces/cuda-quantum# python3 ./examples/python/advanced_vqe.py
= -0.693486
= 0.07810200000000034
= -0.5220219999999998
= -0.050495999999998986
= -0.22196000000000016
= -0.26482599999999934
= -0.4791559999999997
= -0.3505579999999995
= -0.5648879999999998
= -0.3505579999999995
= -0.3076919999999994
= -0.26482599999999934
= -0.7363520000000001
= 0.16383400000000048
= -0.5220219999999998
= -0.5220219999999998
minimized = -0.5220219999999998
optimal theta = -0.006162919501516